### PR TITLE
Add .agents/plans archive and traceability conventions

### DIFF
--- a/.agents/notes.md
+++ b/.agents/notes.md
@@ -1,6 +1,6 @@
 # Agent notes (diary)
 
-**Home:** [hugo-agent-zero/hugo-agent-zero](https://github.com/hugo-agent-zero/hugo-agent-zero) (HQ). Imported from the local monorepo 2026-08-28. SOT copy may lag until the Cursor workspace switches.
+**Home:** [hugo-agent-zero/hugo-agent-zero](https://github.com/hugo-agent-zero/hugo-agent-zero) (HQ). This SOT copy may lag.
 
 This file is a **diary**: one file, dated sittings, newest first. Not daily files. Not Issues.
 
@@ -12,13 +12,13 @@ This file is a **diary**: one file, dated sittings, newest first. Not daily file
 
 Mention tickets in prose (`Open Issue #4 — Restore main tag + skip to main`). Do not use this file as the backlog. Issues stay the tickets; notes stay the story.
 
-Stable kit facts belong in root `AGENTS.md`.
-
 **Layout:**
 
 - **Now** (top) — a few live lines for agent cold start (next ticket, hard locks). Strike when superseded; do not rewrite the rest of the file to match.
 - **Focus** — historical snapshot. Leave it. New work goes in Meetings.
-- **Meetings** — the diary. `### YYYY-MM-DD — …`, newest first. Never rewrite or delete an old sitting. A one-line status on an old entry is OK.
+- **Meetings** — the diary. `### YYYY-MM-DD — …`, newest first. Never rewrite or delete an old sitting. A one-line status on an old entry is OK. Optional **Plans:** bullets link to [plans/](plans/) when Plan mode was used that session.
+
+Stable kit facts belong in root `AGENTS.md`. **Plans** (Plan-mode artifacts) live in [plans/](plans/) — see **Plans (project archive)** in [AGENTS.md](../AGENTS.md).
 
 ## Assistant style (default)
 
@@ -36,28 +36,28 @@ Stable kit facts belong in root `AGENTS.md`.
 
 ### Now
 
-- **Next:** Open Issue [#4](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/4) — Restore main tag + skip to main. Last launch-must kit ticket before shifting to HAZ.com content.
-- **Issue first:** HQ issue before coding. PR `Refs hugo-agent-zero/hugo-agent-zero#N`; issue gets the PR URL. Branch `feat/N-short-slug` when we remember. [#38](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/38). Agent opens PRs; Mark merges. Do not merge `main`.
+- **Next sitting:** Pre-#21 in order — (1) [#26](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/26) light meta-debugger smoke on live (home + blog single + one page; Meta/X/LinkedIn; fix **global** head_tags only), (2) Pico **fuchsia** (close [#12](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/12), new issue; vendor in core + child `1_main`), (3) [#21](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/21) HAZ.com content — **blog = FAQ/How To** (additive posts, e.g. swap Pico theme, change font; GH UI upload path for child-only tweaks).
+- **Launch musts:** all done ([#4](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/4) closed 2026-09-01).
+- **Issue first / PR workflow** locked; Mark merges; do not merge `main`.
 
 ### Focus
 
-- ~~**Tomorrow (2026-08-29):** Finish HQ **Issues** from notes (capture only — don’t execute the tickets). Then overlay light mode when coding resumes.~~ **2026-08-31:** executing tickets. Overlay look closed enough ([#7](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/7)/[#8](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/8)).
-- **HQ is live (2026-08-28):** [hugo-agent-zero/hugo-agent-zero](https://github.com/hugo-agent-zero/hugo-agent-zero) — Issues + signpost README + this file. Not a Hugo module. Wiki off. `main` ruleset: no force-push/delete, PRs required (0 reviews). Chat nickname **HQ**. **Git:** agent opens PRs; Mark reviews (at least) and merges. Agent does not merge `main`. Local clone: `C:\_au\work\hugo\dev\hugo-agent-zero-org\hugo-agent-zero`. `gh` 2.98.0, logged in as AlchemyUnited.
-- ~~**Issues started (not doing the work now):** [#2](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/2) kit READMEs → HQ; [#3](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/3) Issues/Wiki/Discussions off on non-HQ; [#4](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/4) `<main>` + skip-to-main (title tweak later); [#5](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/5) default OG image. CF analytics issue not filed (Starbucks/`gh` timeouts). Keep filing one-by-one.~~ **2026-08-31:** #2/#3/#5 done; Open Issue #4 still open.
-- ~~**Still coding:** Overlay **light mode** (Mark saw issues). Field **white at rest / chrome on focus**. Parked chrome: `<main id="haz_main">` + skip-to-main (atom `main_wrapper_000` exists; multiplier `_home_main_000` parked — no `<main>` in HTML today). **Contact form = v2.** Parked: OG image; semver tags; PF CSS sibling product; `hugo-agent-zero-com` org.~~ **2026-08-31:** Overlay look [#7](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/7)/[#8](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/8) closed. Open Issue #4 for `<main>` + skip. Card vs chip fill parked. Parked: semver tags; PF CSS sibling (`haz_pf.css`); `hugo-agent-zero-com` org; pink→lime / Godzilla.
-- **Contact / list (locked enough):** Hugo has no POST. **Worker** = old WP AJAX. Spam: CF bot fight ± **Turnstile**; CleanTalk optional. **One people vendor = HubSpot** (free CRM + Forms API + small branded blasts). No second ESP. Beehiiv = paid bespoke adapter later. **HAZ.com Contact** = LinkedIn Page Message (bespoke/paid); **HQ Issues** = kit. **DBC:** real contact form + maybe HS newsletter; **Substack = presence/social**, not the email channel; **no iframes**.
-- **Responsive images (locked, not built):** Sibling shortcode (not `haz key=`). Page-bundle stem + `-sm`/`-md`/`-lg`/`-xl` if present. Settings table for widths + **`sizes` is the contract**; srcset is the menu. No `<picture>` now (art direction = later issue).
-- ~~**Tomorrow (2026-08-28), first:** Overlay **light mode**… Then README one-by-one; Issues home; `hugo-agent-zero-com` org.~~ **HQ / Issues home started 2026-08-28.** Overlay look closed 2026-08-31. Skip-to-main still Open Issue [#4](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/4). GH Pages search/home URLs **fixed** (child pin core PR #14).
+- **Next (when back):** HQ [#4](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/4) — `<main>` + skip-to-main. Last launch-must kit ticket before shifting to HAZ.com content. [#21](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/21)/[#22](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/22) come from writing the site, not homework first.
+- **Issue first (locked 2026-08-31):** HQ issue before coding. PR mentions `hugo-agent-zero/hugo-agent-zero#N`; issue gets the PR URL. Branch `feat/N-short-slug` when we remember. [#38](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/38). Agent opens PRs; Mark merges. Do not merge `main`.
+- **Launch musts:** [#2](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/2) READMEs → HQ **done**; [#3](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/3) Issues/Wiki/Projects off on core/child/content **done**; [#5](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/5) default OG image **done** (core PR #20, child pin #20, Pages). [#4](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/4) still open.
+- **Search DRY [#11](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/11) closed.** Toggle ≠ modal: `script_toggler` (class on `html`) vs `script_modal` (`showModal`). Menu vs search. Slot `inner` → `content`. Old hamburger/search JS parked then dropped from sysMan; delete files later [#36](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/36). Overlay look [#7](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/7)/[#8](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/8) closed (recheck if pink→lime [#12](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/12)). `fn_tag_script` stays with enqueue [#34](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/34).
+- **`content/pages/` is organization only.** Do not publish `/pages/` ([#37](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/37), content PR #2 merged). Children still publish.
+- ~~**Tomorrow (2026-08-28), first:** Overlay **light mode**… Then README one-by-one; Issues home. **Contact form = v2.**~~ Overlay look closed enough ([#7](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/7)/[#8](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/8)). Contact still v2.
 - **EOD 2026-08-27:** Search overlay Refine ~99% **dark mode**. Core PR #10 merged (`76b8ef9`); child pin + Pages. Parked: pink→lime / Godzilla; PF CSS as sibling repo; bookkeeping below.
 - ~~**Paused (2026-08-27, afternoon):** Search overlay polish — Mark doing a full review later. **Open:** chip type is still Pagefind’s size, not the site default (hosts inherit; chips don’t). Card/chip background still parked (inspector). Core `main` `094beeb` (PR #4); child pointed at that (PR after). Live via content **pages** workflow.~~ **Superseded same day** — overlay polish ran through core PRs #5–#9 (`1fb3311`); live via content **pages**. Chip type inherit mostly landed; card vs chip fill still parked.
-- ~~**After search is complete — bookkeeping:** (1) Notes home — 4th repo.~~ **HQ created 2026-08-28.** ~~(3) **Universal modal JS** — generic open (selector + `haz_state__*`); hamburger stays a panel. Also parked DRY: `inner` → `content`; `fn_tag_script`.~~ **2026-08-31:** toggle vs modal landed; `inner` → `content`. Still parked: (2) **Kit org vs HAZ.com org** — `hugo-agent-zero` = product; separate org for site forks, name like `hugo-agent-zero-com` (not `---`). `fn_tag_script` with enqueue [#34](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/34).
+- ~~**After search is complete — bookkeeping:** (1) Notes home… (3) Universal modal JS… `inner` → `content`; `fn_tag_script`.~~ HQ exists. Modal vs toggler landed 2026-08-31. Still parked: kit vs HAZ.com org; `fn_tag_script` with enqueue [#34](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/34).
 - **Holy grail (2026-08-18):** GitHub Hugo modules + Pages **passed**. Public core / child / content + Pages = **kit shipped** (quiet alpha). SOT monolith stays local (no remote; don’t edit unless asked). Org clones: `C:\_au\work\hugo\dev\hugo-agent-zero-org\`.
 - **Pagefind overlay shipped (2026-08-26).** Kit search is Pagefind 1.5.x Component UI, local assets, not CDN / hugomods. Overlay = HAZ `<dialog>` + `<pagefind-input>` + `<pagefind-results>` (not `<pagefind-searchbox>` / not their modal-trigger). Off = graph only (header search **and** `block_main_pre.search`). **`settings.search.pagefind` deleted.** Filters = next after overlay polish. Core PR #1 merged (`fcd3cd4`); child pinned + merged. Live: https://hugo-agent-zero.github.io/hugoagentzero_com-content/ — content Pages dispatch still needed after child merge (content has no rebuild on child merge).
 - **Pagefind is kit search (locked 2026-08-20).** Not a `go.mod`; post-`hugo` indexer (`npx pagefind@1.5.2 --site public`). JS/CSS **local** (`public/pagefind/`, `relURL`). Index hook: `data-pagefind-body` on page/blog `<article>`.
 - ~~**Next coding — Pagefind chrome:** POC works; layout/aesthetics next after Mark skims Pagefind modal+trigger docs.~~ **Done 2026-08-26** — HAZ dialog + header icon `showModal`; not Pagefind’s modal-trigger.
-- ~~**Pagefind composition (do this when we restyle):** today’s `search_pagefind_000` is a blob…~~ **Done 2026-08-26** — blob deleted; folder atoms + organism `search_pagefind_modal_000`; named slots (`close_icon`, `inner`); multiply in sysMan. ~~Parked DRY: rename `inner` → `content`; generic open JS; `fn_tag_script`.~~ **DRY 2026-08-31** — `content` slot; generic toggler + modal. `fn_tag_script` still enqueue.
-- ~~**Parked (still):** overwrite core `static/defaults/meta_tag_default_image.png` (1200×630, **same name**), push core, pin child, Pages.~~ **Done 2026-08-31** — HQ [#5](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/5).
-- ~~**Launch bar:** Contact form is kit — vendor TBD.~~ **Updated 2026-08-28:** HS = people vendor; Worker + Turnstile; HAZ.com ≠ a form (LinkedIn + HQ Issues). DBC dogfoods the form.
+- ~~**Pagefind composition:** … named slots (`close_icon`, `inner`); … Parked DRY: rename `inner` → `content`; generic open JS; `fn_tag_script`.~~ **DRY 2026-08-31** — `content` slot; generic toggler + modal; `fn_tag_script` still enqueue.
+- ~~**Parked (still):** overwrite core `static/defaults/meta_tag_default_image.png`…~~ **Done 2026-08-31** — HQ [#5](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/5).
+- **Launch bar:** Search **POC unblocked**. **Contact form is kit** — we’ll pick a backend *we* like, then integrate (same arc as Pagefind). Mailto/social is not the n00b story. Vendor TBD; Hugo won’t POST for us. Other Atomics come from dogfood. Then HAZ.com content + READMEs.
 - ~~**Launch bar:** Search POC unblocked. Email / social @ for contact is enough (form later, nicer on CF).~~
 - ~~**EOD 2026-08-19:** Sit. First thing next: OG default image, **then** search spike.~~ Search went first. Workflow: **dev local, ship when tested** — but this sitting, module pins mean **push to GH to see it live**.
 - ~~**Launch bar:** **Search is the blocker.**~~
@@ -300,61 +300,35 @@ Stable kit facts belong in root `AGENTS.md`.
 
 ## Meetings
 
-### 2026-09-01 — Notes are a diary
+### 2026-09-01 — #4 shipped; debt tidy; pre-#21 queue
 
-**Locked:** One file, dated sittings, newest first. Not daily files. Not Issues. Notes show the time + thoughts that went into the project, remind us what we discussed, and give the next person context. Mention tickets in prose (`Open Issue #4 — Restore main tag + skip to main`). Do not use notes as the backlog.
+**Shipped / closed:** [#4](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/4) `<main>` + skip-to-main (core + child PRs; `main: false` test on home/blog index; restore defaults child #23). [#40](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/40) dropped parked Simple from child sysMan (child #24). [#41](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/41) Pagefind dialog moved below footer (child #25; live OK). [#34](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/34) comment: composition slots vs enqueue lanes — no `block_main_post_enqueue`.
 
-**Write:** Append a `### YYYY-MM-DD` heading per sitting. Never rewrite or delete an old meeting. Strike a **Now** / Focus line when superseded; do not remove. Wrap-up = new diary entry only. Agent cold start = newest meeting + **Now**.
+**Kit stance:** Launch-must bar cleared. Module workflow (core → child pin → content Pages) feels slow then **right** — review at each layer = confidence. Ready to **alpha / dogfood** HAZ.com; not “finished product.”
 
-**This PR:** Restore the original 2026-08-28 import meeting (it had been rewritten). Keep the later 2026-08-28 EOD sitting. Restore truncated Focus lines in full, then strike + status.
+**Pre-#21 (agreed):** Don’t go crazy on debuggers — smoke [#26](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/26) on a few URL shapes so new pages inherit good meta; wider pass after real content. Then Pico pink → **fuchsia** (bolder; [#12](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/12) lime/Godzilla superseded). Then [#21](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/21).
+
+**Parked:** [#22](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/22) Getting Started; contact form v2; enqueue [#34](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/34).
+
+**EOD — #21 content model:** Site docs via **blog as FAQ/How To** — one question per post, keep adding (swap Pico theme, different font, etc.). Pipes/architecture elsewhere; issues stay tickets. **GH-only path:** download Pico CSS → upload to child `assets/child/css/pico/` → sysMan `1_main: child/css/pico/…` (no core PR required). Copilot + Codespaces can help; bare GH UI needs the how-to, not magic.
+
+**Plans:**
+- [#41 dialog + enqueue note](plans/%2341_dialog_%2B_enqueue_note_af4fe94a.plan.md) — HQ [#41](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/41), child [PR #25](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/25); shipped
+- [Drop Simple sysMan](plans/drop_simple_sysman_917a01c3.plan.md) — HQ [#40](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/40), child [PR #24](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/24); shipped
 
 ### 2026-08-31 — HQ execute; search DRY; launch musts; /pages/; pause on #4
 
-**Next:** [#4](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/4) `<main>` + skip. Mark out (errands). Confirm live `/pages/` is 404, then close [#37](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/37).
+**Next:** [#4](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/4) `<main>` + skip. Mark out (errands).
 
-**Process:** HQ Issues as shared brain. Issue **before** code ([#38](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/38)): PR `Refs hugo-agent-zero/hugo-agent-zero#N`; issue gets PR URL; branch `feat/N-short-slug` when we remember. Agent PRs; Mark merges. Do not merge `main`. Don’t dual-write SOT unless asked. PRs live on the repo you changed — HQ open-PR filter empty after merge is expected.
+**Process:** HQ Issues as shared brain. Issue **before** code ([#38](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/38)): PR `Refs hugo-agent-zero/hugo-agent-zero#N`; issue gets PR URL. Agent PRs; Mark merges.
 
-**Search DRY ([#11](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/11) closed):** Toggle (`classList` on `html`) and modal (`showModal`) are **not** one script — more different than the same. Menu uses toggler; search uses modal. Overlay look [#7](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/7)/[#8](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/8) closed (recheck on pink→lime [#12](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/12)). Slot `inner` → `content`. Scripts instance once under `body_end_scripts`; sysMan `enabled` is the include switch (no settings flag; enqueue stays parked). Old hamburger/search JS parked then dropped from child sysMan; delete files later [#36](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/36). `fn_tag_script` stays with [#34](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/34). Don’t put `data-haz_toggler` on search.
+**Search DRY ([#11](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/11) closed):** Toggle (class on `html`) and modal (`showModal`) are **not** one script. Overlay look [#7](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/7)/[#8](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/8) closed (recheck on [#12](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/12)). Slot `inner` → `content`. Old JS parked then removed from sysMan; delete files [#36](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/36). `fn_tag_script` → [#34](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/34).
 
-**Launch musts:** #2 READMEs → HQ **done**. #3 Issues/Wiki/Projects off on core, child, `hugoagentzero_com-content` **done** (leftover public `hugo-agent-zero-child-content` not changed). #5 OG image **done** (core PR #20, child pin #20, Pages; cache-bust if old art sticks). #4 not started. [#21](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/21)/[#22](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/22) = writing HAZ.com, not kit homework. Contact form / LinkedIn contact / filters / lime / CF / semver / enqueue / library / Pages auto-rebuild [#23](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/23) are not launch blockers.
+**Launch musts:** #2/#3 done (READMEs → HQ; Issues/Wiki/Projects off). #5 OG image live. #4 not started. #21/#22 = writing HAZ.com.
 
-**`/pages/`:** Folder is organization only — don’t emit a public section index ([#37](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/37); content PR #2 merged, `_build.render: never`). Children still publish. Don’t hide from Pagefind only.
+**`/pages/`:** Folder is organization only ([#37](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/37); content PR #2 merged). No public section index.
 
-**Git:** Core/child clones often have local dirt (pagefind, LICENSE CRLF). PRs add only intended files. Don’t `go mod tidy` on child. Pin with `go get github.com/hugo-agent-zero/hugo-agent-zero-core@<sha>`. Content Pages: **new** `workflow_dispatch`, not re-run.
-
-### 2026-08-28 (later) — HQ live; Issues started; forms/images locked; EOD
-
-_Same-day EOD sitting. The earlier import meeting is the next heading (was rewritten in an unmerged notes commit; restored 2026-09-01)._
-
-**Shipped:** GitHub CLI 2.98.0 (AlchemyUnited, SSH). Child pin core PR **#14** — live logo + Pagefind hits share one `/hugoagentzero_com-content/`. HQ repo created (public, Issues on, Wiki off). Notes imported ([PR #1](https://github.com/hugo-agent-zero/hugo-agent-zero/pull/1) — agent squash-merged; Mark said don’t merge again). `main` ruleset: no force-push/delete, require PR. Local HQ: `hugo-agent-zero-org/hugo-agent-zero`.
-
-**Git (re-locked):** Agent opens PRs. Mark reviews (the skim gate) and merges. Do not merge `main`.
-
-**Issues filed (capture only):** [#2](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/2) READMEs → HQ; [#3](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/3) kit Issues/Wiki/Discussions off; [#4](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/4) `<main>` + skip (title touch-up later); [#5](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/5) OG default image. Continue the pile tomorrow. No “inbox milestone.”
-
-**Locked — HQ:** Kit ≠ company. Human docs → HAZ.com, not Wiki. Notes = cliff notes (not Issues). Don’t dual-write SOT.
-
-**Locked — forms / lists:** Worker replaces WP AJAX. CF bot fight ± Turnstile; CleanTalk optional. **HubSpot only** for people (CRM, contact, small newsletter). Beehiiv = paid extra adapter. HAZ.com Contact = LinkedIn Page Message (bespoke/pay). HQ Issues = kit. DBC: real contact + maybe HS list; Substack = social/presence, not the email channel; no iframes.
-
-**Locked — images (not built):** Sibling shortcode; page resources; stem + optional `-sm`…`-xl`; **`sizes` is the magic**; srcset from files that exist. `<picture>` later, not a priority.
-
-**Chrome:** Still no HTML `<main>` (`_home_main_000` parked). Overlay light mode still open.
-
-**Next:** Finish HQ Issues from notes. Push this notes branch. Don’t start executing tickets until the inbox is the record. Overlay light mode when coding.
-
-### 2026-08-28 — GH CLI; Pages URLs; HQ repo; notes move here
-
-_Status: notes import merged as PR #1. Same-day EOD sitting is the heading above. Open Issue #4 still covers `<main>` + skip._
-
-**Shipped:** GitHub CLI 2.98.0 (`gh auth login` as AlchemyUnited). Child pin core PR **#14** landed — live logo and Pagefind result URLs share one `/hugoagentzero_com-content/` prefix. HQ: [hugo-agent-zero/hugo-agent-zero](https://github.com/hugo-agent-zero/hugo-agent-zero) (public, Issues on, Wiki off). This notes file imported from the local monorepo onto a PR.
-
-**Locked:** HQ = Issues + signpost README + cliff-notes file. Not core (kit ≠ company). Chat name **HQ**; GitHub slug = org name. Human docs → HAZ.com, not GitHub Wiki. Issues ≠ notes. Branch + PR for HQ README/notes so Mark skims. `gh` can open PRs now.
-
-**Not `<main>`:** No HTML `<main>` in the live graph. `main_wrapper_000` (`tag: main`, `id: haz_main`) exists; multiplier `_home_main_000` is parked. Skip-to-main parked with it. Figure out later.
-
-**SOT:** Local monorepo still has a copy; leave it until Cursor workspace includes HQ. Don’t dual-write.
-
-**Next:** Merge this notes PR. Kit README “go to HQ for Issues.” Disable Issues/Wiki/Discussions on core / child / content. Overlay light mode; then `<main>` + skip link when we pick chrome back up.
+**Git:** HQ has no PRs for kit work — those live on core/child/content. Open filter empty after merge is expected.
 
 ### 2026-08-27 — Search overlay Refine; inspector day; haz_pf parked
 

--- a/.agents/plans/#41_dialog_+_enqueue_note_af4fe94a.plan.md
+++ b/.agents/plans/#41_dialog_+_enqueue_note_af4fe94a.plan.md
@@ -1,0 +1,66 @@
+---
+name: "#41 dialog + enqueue note"
+session: 2026-09-01
+status: shipped
+hq_issue: https://github.com/hugo-agent-zero/hugo-agent-zero/issues/41
+child_pr: https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/25
+related:
+  - HQ #34 — composition vs enqueue lanes (comment only)
+overview: Ship #41 as a one-slot sysMan move (search dialog lower in DOM). Add a design comment on parked enqueue issue #34 — no enqueue revival now.
+todos:
+  - id: 41-move-slot
+    content: "Child PR: move search from block_main_pre to block_main_post (before body_end)"
+    status: completed
+  - id: 34-comment
+    content: "Comment on HQ #34 with composition vs enqueue lanes + #41 pointer"
+    status: completed
+  - id: 41-verify
+    content: "Smoke: dialog low in DOM, search still works from header"
+    status: completed
+isProject: false
+---
+
+# #41 dialog move + enqueue issue note
+
+## Short answer to your question
+
+You are **not** overthinking the *idea* of head vs foot zones — HAZ already has them, just under different names:
+
+| Intent | Already exists | Parked |
+|--------|----------------|--------|
+| Up / head | `head_main` — meta, `framework_css` | `_enqueue_head` atom + `_enqueue.yaml` (asset registry) |
+| Body early | `block_main_pre` — skip, header, **search (today)** | — |
+| Body late | `block_main_post` → `body_end` → `body_end_scripts` (toggler, modal JS) | `_enqueue_footer` atom |
+| Hugo content | `{{ block "main" }}` in `baseof.html` | — |
+
+**Two lanes — keep them separate:**
+
+- **Composition slots** = markup landmarks (header, footer, `<dialog>`, skip). Order in multipliers.
+- **Enqueue** ([#34](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/34)) = declarative **asset** lists (CSS/JS paths by `location: head|footer`). Not loaded today; `_enqueue_000.html` is parked MVP.
+
+The Pagefind dialog is **markup**, not enqueue. Moving it does not need `block_main_post_enqueue` or a new multiplier — that would duplicate `body_end` and blur the lanes.
+
+## #41 — KISS implementation (child only)
+
+In child `multipliers.yaml`:
+
+1. Remove `search` from `block_main_pre.props.order`.
+2. Add `search` to `block_main_post.props.order` **before** `body_end` (after `post_footer`).
+3. Move the `search` child block from `block_main_pre.children` to `block_main_post.children` (same `inst: search_pagefind_modal_000`).
+
+Header trigger unchanged. `script_modal` still finds dialog by id.
+
+**Verify:** build; search opens from header; view source shows `<dialog>` after footer, before `body_end_scripts`; skip → header → `<main>` unchanged.
+
+Branch `feat/41-search-dialog-dom`. PR refs [#41](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/41). Mark merges; do not merge `main`.
+
+## Enqueue issue #34 — comment only (no code)
+
+Post a comment on [#34](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/34) capturing today's decision:
+
+- Head/foot **zones already exist** (`head_main`, `body_end_scripts`); parked `_enqueue_*` is for **assets**, not composition.
+- Overlays/modals belong in **composition** slots (`block_main_post`, low) — see #41.
+- Do **not** add `block_main_post_enqueue`; avoid parallel systems.
+- Revisit #34 when we need ad-hoc asset lists (FA, third-party) without new Atomics — not for dialog DOM position.
+
+No changes to `_enqueue.yaml` or `_enqueue_000.html` in this sitting.

--- a/.agents/plans/README.md
+++ b/.agents/plans/README.md
@@ -1,0 +1,38 @@
+# Plans (project archive)
+
+Cursor Plan mode writes to `~/.cursor/plans/` by default (outside the repo). **This folder** is the git-tracked copy — project DNA alongside [.agents/notes.md](../notes.md).
+
+**Home:** [hugo-agent-zero/hugo-agent-zero](https://github.com/hugo-agent-zero/hugo-agent-zero) (HQ). SOT copy may lag.
+
+## Filenames
+
+Keep the **same basename** Cursor generated (slug + hash), e.g. `41_dialog_+_enqueue_note_af4fe94a.plan.md`. Do not rename to date-only names.
+
+## Frontmatter (traceability)
+
+When copying or authoring a plan here, extend YAML frontmatter so slices tie together:
+
+```yaml
+---
+name: Short title
+session: YYYY-MM-DD
+status: parked | in_progress | shipped
+hq_issue: https://github.com/hugo-agent-zero/hugo-agent-zero/issues/N
+child_pr: https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/N
+core_pr: https://github.com/hugo-agent-zero/hugo-agent-zero-core/pull/N
+related:
+  - HQ #34 — design comment only
+---
+```
+
+Omit keys that do not apply. Mention issues/PRs in prose inside the plan when helpful.
+
+## Wrap-up
+
+On **wrap up** / **meeting notes** / **end session**, if Plan mode was used this session:
+
+1. Copy each session plan from `~/.cursor/plans/` → `.agents/plans/` (skip if unchanged).
+2. Update frontmatter (`status`, PR URLs).
+3. In the Meeting entry in `notes.md`, add **Plans:** bullets linking to files here.
+
+See **Plans** in root [AGENTS.md](../../AGENTS.md) and `.cursor/rules/session-carryover.mdc`.

--- a/.agents/plans/drop_simple_sysman_917a01c3.plan.md
+++ b/.agents/plans/drop_simple_sysman_917a01c3.plan.md
@@ -1,0 +1,37 @@
+---
+name: Drop Simple sysMan
+session: 2026-09-01
+status: shipped
+hq_issue: https://github.com/hugo-agent-zero/hugo-agent-zero/issues/40
+child_pr: https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/24
+overview: Remove parked `_framework_css_simple_css` from child sysMan. Core Simple assets and `framework_css.html` remain for other children.
+todos:
+  - id: hq-issue
+    content: "HQ issue #40 opened 2026-09-01"
+    status: completed
+  - id: delete-node
+    content: Delete _framework_css_simple_css from child atoms.yaml
+    status: completed
+  - id: pr
+    content: PR Refs HQ#40; do not merge main
+    status: completed
+isProject: false
+---
+
+# Drop Simple.CSS from child sysMan
+
+**Status:** Shipped 2026-09-01. HQ [#40](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/40) closed. Child [PR #24](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/24).
+
+## Intent
+
+This child is Pico-only in the graph (`multipliers.yaml` already `inst: framework_css_pico_css`). The parked `_framework_css_simple_css` node was leftover swap-demo, not a live stack. Removed from child sysMan so manifests stay Pico-clean.
+
+**Keep:** `cta_simple_000` (CTA molecule). Core Simple CSS files. `framework_css.html` Atomic. `assets/child/css/simple/simple-override.css` on disk (optional reference for a future Simple child).
+
+## Scope (child PR only)
+
+Delete `_framework_css_simple_css` from child `layouts/_partials/child/data/system_manifest/layouts/atoms.yaml`. No core PR. No graph rewires.
+
+## Verify
+
+`hugo` still emits Pico + `haz.css` + pico-x + child override. No Simple `<link>` in `<head>`.

--- a/.cursor/rules/session-carryover.mdc
+++ b/.cursor/rules/session-carryover.mdc
@@ -1,0 +1,16 @@
+---
+description: Read .agents/notes.md at session start; append a diary entry on wrap-up
+alwaysApply: true
+---
+
+# Session carryover
+
+See **Session carryover** in [AGENTS.md](../../AGENTS.md) and [.agents/notes.md](../../.agents/notes.md). Notes are a **diary** (one file, dated sittings). HQ is home; SOT may lag.
+
+**Start of session:** On a **new chat** or when continuing prior work, read `.agents/notes.md` — the **newest Meeting** and **Now** if present. One-line focus ack when relevant; no recap dump. Do not re-read every turn in the same thread.
+
+If a new session looks likely and **Meetings** is stale vs recent work, ask once: *I sense we're about to start a new session, but we never updated `.agents/notes.md` from the last session — would you like me to do the last session now?* Backfill a dated entry only if yes. Do not rewrite Focus or old meetings.
+
+**Wrap-up:** On **wrap up** / **meeting notes** / **end session** → append a dated Meeting (newest first). Strike a **Now** line if it changed. Do not rewrite Focus or prior sittings. If Plan mode was used, **archive plans** per **Plans (project archive)** in [AGENTS.md](../../AGENTS.md): copy to `.agents/plans/`, update traceability frontmatter (`hq_issue`, PR URLs, `status`), add **Plans:** bullets in the Meeting entry.
+
+If language suggests the session is ending (good night, done for today, pick up tomorrow, etc.) without an explicit notes request, ask once: *Do you want me to update `.agents/notes.md`?* Update only if yes. Do not append minutes on every reply.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,134 @@
-# hugo-agent-zero (HQ) — context for assistants
+# hugo-agent-zero — context for assistants
 
-This repository is **project HQ**: Issues, session notes, and a signpost README. It is **not** a Hugo module and does not build a site.
-
-Kit conventions (Atomics, sysMan, CSS naming, Hugo-first) live in **core** and the local monorepo. Do not copy those here.
+Stable facts and conventions. For session carryover (the diary), see [.agents/notes.md](.agents/notes.md). Notes home is HQ: [hugo-agent-zero/hugo-agent-zero](https://github.com/hugo-agent-zero/hugo-agent-zero). The SOT copy may lag.
 
 ## Communication
 
-Follow **Assistant style (default)** in [.agents/notes.md](.agents/notes.md).
+Assistant replies: follow the **Assistant style (default)** section in [.agents/notes.md](.agents/notes.md). A matching Cursor rule under `.cursor/rules/` reinforces the same preferences.
+
+- Default to short, conversational replies (TL;DR first).
+- Give the minimum useful answer first; add depth only when the user asks.
+- For nuanced topics, offer: "Want the deeper version?" instead of auto-dumping detail.
+- If the user shows confusion, switch explanation style (example, analogy, or concrete diff) rather than repeating the same framing.
+- Avoid repetitive re-explanations; summarize what changed in one or two lines before continuing.
+- When appropriate, offer more than one solution (e.g., "We can do A, B, or C").
+- When appropriate, call out trade-offs and include key pros and cons.
+
+## What this is
+
+- **Hugo** static site (no Node/Python app in-repo).
+- **Config:** [hugo.toml](hugo.toml) — `title` “Hugo Agent Zero”, menus (Home, About), **min Hugo 0.146.0**, `extended = false`.
+- **Content:** [content/](content/) — e.g. `_index.md`, `about.md`; [archetypes/default.md](archetypes/default.md).
+
+## How to work on it
+
+- From repo root: `hugo server` (dev), `hugo` (build to `public/`).
+- Ensure local Hugo meets the minimum in `hugo.toml`.
+
+## Layouts and assets (mental map)
+
+- **Shell:** [layouts/baseof.html](layouts/baseof.html) → [home.html](layouts/home.html), [single.html](layouts/single.html), [list.html](layouts/list.html), etc.
+- **Partials:** atomic-style under [layouts/_partials/](layouts/_partials/) — `atoms/`, `molecules/`, `organisms/`, plus `utils/`, `child/` (brand SVGs, overrides), [sysManifest.yaml](layouts/_partials/child/data/sysManifest.yaml).
+- **Styles:** [assets/css/simple/](assets/css/simple/) and [assets/child/css/](assets/child/css/).
+- **Static:** [static/](static/) — copied as-is.
+
+## Conventions for edits
+
+- Match existing naming and partial structure; avoid drive-by refactors unrelated to the task.
+- Search layouts for `TODO` when touching JS/CSS framework hooks.
+- In YAML/front matter, a leading underscore on a key (for example `_config`, `_props`) means the key is intentionally parked/disabled and retained for reference. Treat this as a valid convention; do not flag `_`-prefixed keys as naming errors by default.
+- Folder Atomics may include **`_preset_example.yaml`** — a non-loaded starter shape (like `.env.example`). Live presets are `preset_*.yaml` beside the Atomic and/or under `content/presets/`.
+- **sysMan first:** if composition can live in the graph (`order`, named slots, `inst` → multiplier), do it there. Do not bake `fn_multiplier` (or equivalent stacking) into an Atomic. Named slots on the Atomic; multiply in sysMan. Others may cheat; HAZ stays pure. One fill slot → **`content`** (match `tag_tag_wrapper`); several slots → role names (`col_brand`, `close_icon`).
+
+## Atomic render boilerplate
+
+Every atom / molecule / organism **render entry** (file-based `*.html` or folder `index.html`) should follow the same shell. Reference (not loaded by Hugo): [.agents/boilerplate/_atomics.html](.agents/boilerplate/_atomics.html). Content FM masters in the same folder: [`_blog_single.md`](.agents/boilerplate/_blog_single.md), [`_page.md`](.agents/boilerplate/_page.md) — full prop catalogs with typical keys live and fringe keys `_`-parked for copy/paste. That folder is primarily for agents; humans can skim it via this section.
+
+- Top locals: `source`, `child`, `thisObj`, `sysManifest`, `context`, `thisObjProps`, `thisChildren`, `thisSource`, `props`, `enabled` (with the `gt (len $thisObj)` guard).
+- **`if enabled`:** emit `fn_html_comment` with `$thisSource`, then the Atomic’s body.
+- **`else if enabled_false`:** `fn_partial` to the `enabled_false` child.
+- **Parents** under `helpers/parents/` are for shared **output** only. Do **not** put the enabled / comment / enabled_false gate in the parent — keep that on the Atomic index (e.g. `cols_two_tag_wrapper_000` → parent for markup).
+- **Organisms:** default to a **single file**. Use a **folder** only with a strong case (e.g. defaults + multiple presets such as `cols_two_tag_wrapper_000`). Not a hard ban — justify the folder.
+
+## CSS naming (HAZ)
+
+We are mostly classless (framework + element styles), but when we invent classes or IDs, follow this so we don’t collide with framework tokens (e.g. Pico `.container`).
+
+- **Namespace:** HAZ-owned classes and IDs use the `haz_` prefix. Custom properties use `--haz_*` (e.g. `--haz_measure`).
+- **Separators:** underscores only in our tokens — no hyphens in `haz_*` names (double-click friendly).
+- **Identity classes are optional:** an Atomic does **not** need a class just because it exists. Prefer classless markup (framework + elements) when one instance is enough (e.g. a lone `<article>`).
+- **When you do add an identity class:** base it on the Atomic/html name most of the time so grep and mental model stay aligned. If the Atomic name includes a role word (e.g. `wrapper`), keep it in the class too (`page_title_wrapper_000` → `haz_page_title_wrapper`) — rare exceptions only. Prefer `__` for true sub-parts of that block (`haz_page_title_wrapper__heading`), not for renaming away the Atomic’s own words.
+- **Light BEM-y join:** `haz_<block>` and `haz_<block>__<element>` (e.g. `haz_header_site`, `haz_header_site__controls`). Do not build deep chains (`haz_a__b__c`); uniqueness stays at the molecule/block — organism wrappers compose with short selector chains if needed.
+- **Page kind on `<body>`** (not UI state): layout/content hooks such as `haz_single`, `haz_list`, `haz_blog`, `haz_page` — set via `routes.yaml` `map_body_attrs`, not on the article shell.
+- **Global UI state** (often on `html`/`body`, JS-toggled): `haz_state__<token>` (e.g. `haz_state__scrolled`, `haz_state__nav_open`). Prefer data attrs already in use (`data-theme`, etc.) where that pattern fits; don’t force every flag into `haz_state__`. Page kind is **not** `haz_state__`.
+- **Framework classes:** never rename Pico (or other vendor) classes; don’t invent bare globals that frameworks own.
+- **Child sites:** optional and up to the child. Child may reuse `haz_`, invent its own prefix, or overlap parent names — if that conflicts with parent, treat it as intentional. HAZ is **not** opinionated about a required `child_` (or other) prefix.
+- **Migration:** apply on new work and **migrate as touched**; no blanket renames of leftover legacy tokens. First migrate pass (2026-07-29): header chrome, brand/SVG classes, nav/buttons/IDs, HAZ utilities, `haz_state__nav_open`.
+
+## Hugo first — when we must
+
+If Hugo already owns a site-graph concern and leans on it at build time, **use Hugo’s model** — do not re-own or subvert it. Otherwise HAZ / `sysManifest` / child data should own the feature.
+
+Examples of Hugo-first: **menus** (`Site.Menus`, `pageRef`, `IsMenuCurrent`), taxonomies/terms, page dates, content bundles. Examples of HAZ-owned: composition (`layouts.yaml`), chrome assembly, CMS payloads, social link lists, presentation defaults.
+
+## Hugo naming (match Hugo, not display English)
+
+Prefer Hugo’s **native identifiers** in manifest `props`, `settings` keys, and front matter—not human labels.
+
+- **Taxonomies:** Profile keys and `props.taxonomy` use Hugo’s **plural** taxonomy names (`categories`, `tags`) — same as `.GetTerms`, URLs, and typical front matter. Optional **`getterms`** on profile/props only when it must differ from the profile key. Display labels live in **`term`**. (`hugo.yaml` `category: categories` is an FM alias only.)
+- **Dates:** Hugo field names (`publishdate`, `lastmod`, `date`)—not display words like “Published” / “Updated” (those belong in `settings.dates.*.term`).
+- **Labels vs keys:** `term`, formats, `link_rel`, etc. are display/behavior in settings; do not use them as lookup keys.
+
+When adding a feature, check [Hugo docs](https://gohugo.io/) for the canonical name before inventing a project alias.
 
 ## Session carryover
 
-[.agents/notes.md](.agents/notes.md) is the project **diary**: one file, dated sittings, newest first. Not Issues. Issues and PRs are the tickets; notes are the story (time + thoughts, what we discussed, context for the next person). Mention tickets in prose.
+Chats can be lost after Cursor updates or new threads. [.agents/notes.md](.agents/notes.md) is the repo-backed **diary** (HQ is home; this SOT copy may lag).
 
-**Start of session:** Read the **newest Meeting** and **Now** if present. One-line focus ack when relevant. Do not rewrite old sittings.
+**What notes are:** one file, dated sittings, newest first. Not daily files. Not Issues.
 
-**Wrap-up:** On **wrap up** / **meeting notes** / **end session** → append a dated Meeting on a **branch** and open a **PR**. Strike a **Now** line if it changed. Do not rewrite Focus or prior sittings. Do not push straight to `main`. Mark skims; the agent does not merge `main`.
+Notes exist to show others the time + thoughts that went into the project, remind us what we discussed, and give the next person context. Mention tickets in prose (`Open Issue #4 — Restore main tag + skip to main`). Do not use notes as the backlog.
 
-Implicit session end (good night, done for today, etc.): ask once whether to update notes; only then.
+**Layout:**
 
-## Git
+- **Now** (top, optional) — a few live lines for cold start (next ticket, hard locks). Strike when superseded; do not rewrite the rest of the file to match.
+- **Focus** — historical snapshot. Leave it. New work goes in Meetings.
+- **Meetings** — the diary. `### YYYY-MM-DD — …`, newest first. Never rewrite or delete an old sitting. A one-line status on an old entry is OK. Optional **Plans:** bullets link to [.agents/plans/](.agents/plans/) when Plan mode was used that session.
 
-- Branch + PR for README, notes, and AGENTS.md.
-- Issues here. PRs for kit code stay on core / child / content.
-- Human-facing docs go on HAZ.com, not a Wiki.
+**Start of session (agent):**
+
+- At the beginning of a **new chat** (or when the user asks to continue prior work), read `.agents/notes.md` — the **newest Meeting** and **Now** if present. Skim older entries only if context is unclear.
+- Briefly acknowledge current focus in your first reply when relevant (one line, not a recap dump). Do not re-read on every turn in the same thread.
+- If this looks like a **new session** and the latest **Meetings** entry is clearly stale (e.g. dated before today, or chat/transcript context shows substantive work since that entry), ask once:
+
+  > I sense we're about to start a new session, but we never updated `.agents/notes.md` from the last session — would you like me to do the last session now?
+
+  If yes, backfill a Meeting entry from what you can recover (prior transcript, git diff, or the user's recap). Do **not** rewrite Focus or old meetings. If no, continue without updating.
+
+**End of session (agent):**
+
+- **Explicit trigger:** User says **wrap up**, **meeting notes**, or **end session** → append a dated Meeting entry (newest on top). Strike a **Now** line if it changed. Do not rewrite Focus or prior sittings. If Plan mode was used, archive plans per **Plans (project archive)** above. HQ notes: branch + PR; do not merge `main`.
+- **Implicit wrap-up:** If the user's language suggests the session is ending (e.g. good night, that's all for now, I'll pick this up tomorrow, signing off, done for today) **without** asking for notes, ask once:
+
+  > Do you want me to update `.agents/notes.md`?
+
+  Only update if they say yes. Do **not** append minutes on every reply or without confirmation when the trigger was implicit.
+
+## Plans (project archive)
+
+Cursor Plan mode saves to `~/.cursor/plans/` by default (outside the repo). **Git-tracked copies** live in [.agents/plans/](.agents/plans/) — same basename Cursor used (slug + hash). HQ is home; SOT copy may lag.
+
+**When to archive:** Any session that used Plan mode for substantive work.
+
+**On wrap-up** (with Meeting notes):
+
+1. Copy each session plan from `~/.cursor/plans/` → `.agents/plans/` (skip if already present and unchanged).
+2. Set frontmatter: `session`, `status` (`parked` | `in_progress` | `shipped`), `hq_issue`, `core_pr`, `child_pr`, `related` — omit keys that do not apply. See [.agents/plans/README.md](.agents/plans/README.md).
+3. In the Meeting entry, add **Plans:** bullets linking to archived files (one line each: title, HQ issue, PRs, status).
+
+**During Plan mode:** When creating or updating a plan that maps to kit work, record HQ issue # and expected PR repos in frontmatter or a **Traceability** section at the top of the plan body.
+
+## Cursor-specific (optional)
+
+- Long-lived **rules** can live in `.cursor/rules/` (see Cursor docs). This file is the portable, tool-agnostic entry point.
+- **Plan mode:** Do **not** execute instructions that change the project (edits, non-readonly tools, shell that modifies state). Treat ambiguous asks as planning or discussion unless the user clearly asks to execute. **Double-check with the user:** “If you want me to code or apply changes, please switch to **Agent** mode.”


### PR DESCRIPTION
## Summary

- Add `.agents/plans/` — git-tracked copies of Cursor Plan-mode artifacts (same basename as `~/.cursor/plans/`), with frontmatter for HQ issue, PR URLs, and status
- Document **Plans (project archive)** in `AGENTS.md` and wrap-up steps in `.cursor/rules/session-carryover.mdc`
- Backfill shipped plans for HQ #40 (child PR #24) and HQ #41 (child PR #25)
- Update `.agents/notes.md` — 2026-09-01 meeting + **Plans:** links; diary layout mentions plan archive

## Test plan

- [ ] Skim `.agents/plans/README.md` for frontmatter shape
- [ ] Confirm 2026-09-01 Meeting **Plans:** bullets resolve in GitHub markdown
- [ ] Merge when happy; SOT monolith can sync after merge
