### PR TITLE
Session notes 2026-09-03 — #43 shipped; next HAZ.com content

### DIFF
--- a/.agents/notes.md
+++ b/.agents/notes.md
@@ -36,9 +36,14 @@ Stable kit facts belong in root `AGENTS.md`. **Plans** (Plan-mode artifacts) liv
 
 ### Now
 
-- **Next sitting:** Pre-#21 in order — (1) [#26](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/26) light meta-debugger smoke on live (home + blog single + one page; Meta/X/LinkedIn; fix **global** head_tags only), (2) Pico **fuchsia** (close [#12](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/12), new issue; vendor in core + child `1_main`), (3) [#21](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/21) HAZ.com content — **blog = FAQ/How To** (additive posts, e.g. swap Pico theme, change font; GH UI upload path for child-only tweaks).
+- **Next sitting:** Start **HAZ.com content** (long arc). Write first; break into kit tickets as the site needs them — other issues get done *and* the site takes form.
+- **Parked (simmer):** [#19](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/19) versioning + GH HX — [plans/core_semver_tags_daff550c.plan.md](plans/core_semver_tags_daff550c.plan.md).
+- **Also queued:** Pre-#21 — [#26](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/26) meta smoke, fuchsia, [#21](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/21) vanilla starter gate (site content is the jump-in, not homework first).
 - **Launch musts:** all done ([#4](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/4) closed 2026-09-01).
 - **Issue first / PR workflow** locked; Mark merges; do not merge `main`.
+- **Pages:** after child CSS/module merges, kick a **new** dispatch (re-run keeps the original content SHA).
+- ~~**Next sitting:** Finish [#43] Phase 2… `params.short_desc`…~~ Superseded 2026-09-03 — #43 list + desc meta shipped; HAZ.com content is the jump-in.
+- ~~**Next sitting:** Pre-#21 in order — (1) [#26]… (2) fuchsia… (3) [#21]…~~ Superseded 2026-09-02 EOD / 2026-09-03 — #43 then HAZ.com content.
 
 ### Focus
 
@@ -299,6 +304,47 @@ Stable kit facts belong in root `AGENTS.md`. **Plans** (Plan-mode artifacts) liv
 ---
 
 ## Meetings
+
+### 2026-09-03 — #43 Phase 2–3 + meta columns shipped; next = HAZ.com content
+
+**#43 Phase 2 (shipped):** List row = `li>article` + heading via `props.tag` (blog **h2**) + `content` child. Core [PR #23](https://github.com/hugo-agent-zero/hugo-agent-zero-core/pull/23); child [PR #29](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/29); pin [PR #30](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/30).
+
+**#43 Phase 3 (shipped):** `params.desc_short` / `params.desc_long` (never Hugo `.Summary`). Labels from `settings.desc` — **Summary** / **Overview**. List = short only; single = long else short. Core atom `hugo_page_desc_dt_dd_000`. Core [PR #24](https://github.com/hugo-agent-zero/hugo-agent-zero-core/pull/24); child [PR #31](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/31); content [PR #3](https://github.com/hugo-agent-zero/hugoagentzero_com-content/pull/3); pins [PR #32](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/32) / [PR #33](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/33).
+
+**Meta polish (shipped):** Summary grouped with Cats/Tags; article list unstyled. Child [PR #34](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/34) (restore child-only Pico override rules after a full-file copy oops). **dt/dd columns:** grid `5.5rem` + `minmax(0,1fr)`, `1rem` gap — not a width calc. Child [PR #35](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/35). Mark: `/blog/` looks ~10× better.
+
+**Pages quirk:** content workflow `hugo mod get` content at **dispatch SHA**. Re-running an old run keeps that SHA; always a **new** Pages dispatch after child/content land.
+
+**Next sitting:** HAZ.com content. Long job. Start writing; peel off code tickets when the site needs them — kit issues move *and* the site takes form.
+
+**Plans:**
+- [Blog list / #43](plans/blog_list_main_styling_bafcd32b.plan.md) — Phases 1–3 + meta columns; **shipped**
+
+### 2026-09-02 (afternoon) — #43 Phase 1 shipped; Phase 2 + short_desc planned
+
+*Status 2026-09-03:* Phase 2 + `desc_short`/`desc_long` + meta columns shipped — see Meeting that date.
+
+**#43 Phase 1 (shipped):** Blog index in `<section class="haz_section--blog">`. Pico article card styles on `main` (leave nested article/section alone). Core [PR #22](https://github.com/hugo-agent-zero/hugo-agent-zero-core/pull/22), child [PR #26](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/26), pin [PR #27](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/27); Pages OK. Content pin hygiene [PR #28](https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/28).
+
+**#43 Phase 2 (next jump-in):** Graduate POC list row — `li>article`; title `props.tag: h2`; **reuse** `single_blog_meta_wrapper` (dl/dt/dd); drop handmade Categories/Tags. One launch Atomic; variants later.
+
+**`params.short_desc` (follow-on):** Never Hugo `.Summary` (auto-fallback blocker). Put in meta box as Summary/Overview via settings `term`. Optional h2/h3 later.
+
+**Plans:**
+- [Blog list / #43](plans/blog_list_main_styling_bafcd32b.plan.md) — Phase 1 shipped; Phase 2 + short_desc; later **shipped** 2026-09-03
+
+### 2026-09-02 — Plans archive shipped; #19 versioning parked (HX)
+
+**HQ:** [PR #42](https://github.com/hugo-agent-zero/hugo-agent-zero/pull/42) merged — `.agents/plans/` archive, `AGENTS.md` Plans section, session-carryover rule, backfilled #40/#41 plans + **Plans:** on 2026-09-01 Meeting.
+
+**#19 versioning (discussed, not executed):** Go has no npm-style ranges. HX goal = no pin babysitting. Locked direction: core branch **`v1.x.x`** = latest compatible 1.x (`hugo mod get …@v1.x.x`); tags (`v1.0.0`, `v1.2.3`) for lock-in; **`v2.x.x`** only when something breaks. Same rule for live Pages and site copies (true dogfood). Child pin PRs after every core merge go away once CI/child use `@v1.x.x`.
+
+**Site start story:** kit org keeps core; site org (e.g. haz-com) owns **child + content copies only** — do **not** copy core. Prefer GitHub **templates**, not forks (forks imply PRs back; we won’t take those). Today: content starter is a template; **child is not**. Template flag ≠ “Start here.”
+
+**Sandbox vs starter:** child/content have been a **dev sandbox**. Public “Start here” waits on intentional **vanilla demo** cleanup (Lorem, thin menus) — separate from HAZ.com product content [#21](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/21). Cleanup sucks time but needed.
+
+**Plans:**
+- [Versioning + GitHub HX](plans/core_semver_tags_daff550c.plan.md) — HQ [#19](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/19); parked
 
 ### 2026-09-01 — #4 shipped; debt tidy; pre-#21 queue
 

--- a/.agents/plans/blog_list_main_styling_bafcd32b.plan.md
+++ b/.agents/plans/blog_list_main_styling_bafcd32b.plan.md
@@ -1,0 +1,156 @@
+---
+name: Blog list main styling
+overview: "HQ #43 — Phase 1 shipped (section + main card). Phase 2: finish list rows — article teasers, title heading via props.tag (blog = h2), reuse single meta. Follow-on: params.short_desc in meta dl."
+todos:
+  - id: wrap-section
+    content: "Phase 1 — Child: section wrapper around blog_index_000; routes map_layouts_entry"
+    status: completed
+  - id: main-card-css
+    content: "Phase 1 — Core pico-x: copy Pico article card styles onto main only; leave article/section alone"
+    status: completed
+  - id: prs-smoke-p1
+    content: "Phase 1 — Core + child PRs refs #43; Pages smoke /blog/ + singles light+dark"
+    status: completed
+  - id: list-row-markup
+    content: "Phase 2 — article + h2 title prop; reuse single_blog_meta_wrapper (dl/dt/dd)"
+    status: completed
+  - id: list-row-css
+    content: "Phase 2 — light row spacing only; keep haz_blog_meta styles"
+    status: completed
+  - id: prs-smoke-p2
+    content: "Phase 2 — core/child PRs refs #43; Pages smoke"
+    status: completed
+  - id: summary-intro-later
+    content: "Follow-on — params.desc_short / desc_long in meta dl (term Summary/Overview); never .Summary"
+    status: completed
+isProject: false
+session: 2026-09-03
+hq_issue: https://github.com/hugo-agent-zero/hugo-agent-zero/issues/43
+status: shipped
+core_pr: https://github.com/hugo-agent-zero/hugo-agent-zero-core/pull/24
+child_pr: https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/35
+related:
+  - Phase 1 core https://github.com/hugo-agent-zero/hugo-agent-zero-core/pull/22
+  - Phase 1 child https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/26
+  - Phase 2 core https://github.com/hugo-agent-zero/hugo-agent-zero-core/pull/23
+  - Phase 2 child https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/29
+  - Phase 3 core https://github.com/hugo-agent-zero/hugo-agent-zero-core/pull/24
+  - Phase 3 child https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/31
+  - content desc FM https://github.com/hugo-agent-zero/hugoagentzero_com-content/pull/3
+  - meta polish + grid columns child https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/34
+  - meta grid child https://github.com/hugo-agent-zero/hugo-agent-zero-child/pull/35
+---
+
+# Blog list structure + main continuity (HQ #43)
+
+Live: https://hugo-agent-zero.github.io/hugoagentzero_com-content/blog/
+
+## Phasing
+
+| Phase | Status |
+|-------|--------|
+| **1 — section + main card** | **Shipped** |
+| **2 — finish the list rows** | **Shipped** |
+| **3 — desc_short / desc_long** | **Shipped** |
+| **Meta columns (grid)** | **Shipped** (child #35) |
+
+---
+
+## Phase 1 (done)
+
+- Blog index in `<section class="haz_section--blog">`
+- Pico `article` card styles copied onto `main` (nested article/section left alone)
+
+---
+
+## Phase 2 — how the row is built today
+
+Spike markup, not finished composition.
+
+[`hugo_pages_list_000.html`](layouts/_partials/haz/atomic/atoms/hugo_pages_list_000.html) — opens `ul`/`ol`, hardcodes `<li>` around each child partial.
+
+[`hugo_pages_list_item_000.html`](layouts/_partials/haz/atomic/atoms/hugo_pages_list_item_000.html) — **hardcoded**:
+
+```html
+<p><a href="…">Title</a> — <time>…</time></p>
+<p>summary</p>
+<p>Categories: …</p>
+<p>Tags: …</p>
+```
+
+- Title is **not** a heading and **not** a prop
+- No `<article>`
+- Date uses wrong context (`.Date` on the dict, not `$context.Date`) — leftover spike smell
+
+sysMan [`blog_pages_list_item_000`](layouts/_partials/child/data/system_manifest/layouts/atoms.yaml) has almost no props.
+
+---
+
+## Phase 2 decisions (locked)
+
+1. **KISS for launch** — one solid row Atomic now; invent `_010` / `_020` later when we need different fields.
+2. **`<li><article>…</article></li>`** — teaser is an article; Pico article chrome stays.
+3. **Title = heading via `props.tag`** — blog sets **`h2`** (under page `h1`). Default if omitted: `h2`.
+4. **Reuse single-post meta, don’t reinvent taxonomies** — drop the POC `Categories:` / `Tags:` `<p>` strings (also fixes the missing space after `Tags:`). Point the row at the same meta stack as singles: [`single_blog_meta_wrapper_000`](layouts/_partials/child/data/system_manifest/layouts/atoms.yaml) → dl / dt / dd (`haz_blog_meta`). sysMan-first: row is mostly **title + meta child**, not a second taxonomy renderer.
+5. **Light hierarchy CSS** only if the reused meta needs list-row spacing tweaks — not a parallel meta design.
+6. **Graduate the POC** — core Atomic + child props; fix leftover spike bugs (e.g. wrong `.Date` context) as we touch the file.
+
+### Shape (launch)
+
+```text
+li
+  article
+    h2 > a (title)     ← props.tag
+    haz_blog_meta …   ← same inst as single: single_blog_meta_wrapper_000
+```
+
+Date/byline follow whatever single meta already does — don’t invent a third place.
+
+### Parked (follow-on after Phase 2 list row) — `params.short_desc`
+
+**Do not use Hugo `.Summary`.** Auto-fallback when empty was a blocker.
+
+**Field:** shipped as `params.desc_short` / `params.desc_long` — empty = omit.
+
+**Primary presentation (locked intent):** add to the **blog meta `dl`** (same box as dates/taxonomies) — `dt` label from settings `term` (e.g. “Summary” or “Overview”), `dd` = value. Sites rename the label without renaming the field.
+
+**Also later:** optional heading presentations (single `h2`, list `h3`) reading the same field — not required for first wiring.
+
+**Phase 2 launch:** title + reuse existing meta (no `short_desc` row yet). Next ticket after list row: settings profile + meta Atomic for `short_desc`.
+
+---
+
+## Phase 2 implementation
+
+### Markup (core + child)
+
+- Rewrite list-item Atomic as a thin shell: `<article>` + heading title link (`props.tag`) + `fn_partial` to meta child (not inline category/tag HTML).
+- Child: `blog_pages_list_item_000` props `tag: h2`; `children` include meta → `single_blog_meta_wrapper_000` (or equivalent slot name).
+- Keep or drop summary in this pass: if single meta doesn’t show summary, prefer **title + meta** for parity; summary can return as its own slot later.
+- List parent keeps wrapping `<li>`.
+
+### CSS
+
+- Only what’s needed so teaser + `haz_blog_meta` read as a row inside the list (gap/margin). Reuse existing meta styles.
+
+### Ship
+
+- Core PR + child PR; ref [#43](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/43); pin + Pages.
+
+---
+
+## Test plan (Phase 2)
+
+- [x] `/blog/` each row: `<li><article><h2><a>…</a></h2>` + same dl/dt/dd meta as singles
+- [x] No handmade `Categories:` / `Tags:` paragraphs; no `Tags:` spacing glitch
+- [x] Outline: one `h1`, post titles `h2`
+- [x] Light + dark smoke
+
+---
+
+## Out of scope
+
+- Vanilla starter / Lorem cleanup
+- Fuchsia theme
+- Reworking single page `<article>` wrappers
+- FAQ redesign

--- a/.agents/plans/core_semver_tags_daff550c.plan.md
+++ b/.agents/plans/core_semver_tags_daff550c.plan.md
@@ -1,0 +1,193 @@
+---
+name: Core versioning v1 branch
+overview: "HX-first versioning + how sites get started. Branch v1.x.x + tags; templates not forks; core upstream. Also: clean child/content into a vanilla out-of-box demo (not the current sandbox). HQ #19."
+todos:
+  - id: branch-v1
+    content: Create branch v1.x.x from current core main; merge policy = compatible 1.x only
+    status: pending
+  - id: tag-v1.0.0
+    content: Tag v1.0.0 on that branch — baseline snapshot (optional lock point)
+    status: pending
+  - id: child-and-pages
+    content: Child go.mod + pages.yml both use hugo mod get core@v1.x.x — same path for live site and site copies
+    status: pending
+  - id: child-template-flag
+    content: "Mark hugo-agent-zero-child as a GitHub template (content starter already is)"
+    status: pending
+  - id: vanilla-demo
+    content: "Intentional cleanup — child + content starter as vanilla out-of-box demo (Lorem, thin menus); separate from HAZ.com product content"
+    status: pending
+  - id: doc-hx
+    content: "HQ #19 + READMEs — versioning + template-not-fork + do-not-copy-core (plain English)"
+    status: pending
+  - id: verify
+    content: Pages build + close #19
+    status: pending
+isProject: false
+session: 2026-09-02
+hq_issue: https://github.com/hugo-agent-zero/hugo-agent-zero/issues/19
+status: parked
+---
+
+# Versioning + GitHub HX (HQ #19)
+
+Versioning, Go modules, and GitHub “how do I start a site?” overlap. Solve them together so mum doesn’t touch pins or open PRs nobody wants.
+
+---
+
+## Problem (plain English)
+
+Go does **not** have npm-style ranges (`^1.0.0`). A pin is exact: tag, branch tip, or ugly hash.
+
+**Optimize for:** merge core → site still builds → humans don’t babysit `go.mod`. Not for HackerNews DX.
+
+**Also:** “fork” on GitHub implies PRs back. That is **wrong** for a unique site. Sites need an **independent copy**, not a fork network.
+
+---
+
+## Who owns what
+
+| Org (names TBD) | Owns | Role |
+|-----------------|------|------|
+| **Kit** (`hugo-agent-zero`) | core, child *starter*, content *starter*, HQ | Shared kit |
+| **Site** (e.g. `haz-com`) | that site’s child + content copies | One unique site |
+
+**Default path to start a site:** copy **child** + **content** only. **Do not copy core** — pull it as a module (`@v1.x.x` or a lock tag).
+
+We use the live demo the same way first (true dogfood), then the site org follows the same rules.
+
+---
+
+## Template, not fork
+
+| Mechanism | Meaning | For HAZ sites? |
+|-----------|---------|----------------|
+| **Fork** | Linked copy; GitHub expects PRs upstream | **No** — we won’t take site PRs into kit child/content |
+| **Use this template** | New independent repo; no fork link | **Yes** — mum-proof |
+
+**Today on GitHub:**
+
+| Repo | Template? |
+|------|-----------|
+| `hugo-agent-zero-child` | **No** — turn on |
+| `hugo-agent-zero-child-content` | **Yes** |
+| `hugoagentzero_com-content` | **No** — live demo content; not the starter |
+
+Docs / Getting Started should say **template**, never “fork,” unless someone is contributing to core.
+
+---
+
+## Sandbox vs vanilla demo (intentional cleanup)
+
+**Today:** kit **child** and **content** have been a **dev sandbox** — experiments, demo posts, half-baked pages (content more than child). Fine for building the kit.
+
+**They are not a “Start here” handoff**, even if GitHub marks them as templates. A template flag only means “Use this template” creates a copy — it does **not** mean the copy is fit for someone else.
+
+**Gate:** do **not** tell people to start from these until the build reads as a **vanilla out-of-the-box demo** — clear structure, Lorem / light placeholder copy, thin menus, no sandbox clutter.
+
+| Repo | Intent |
+|------|--------|
+| **Child starter** | Clean sysMan / chrome defaults — product-ready, not a junk drawer |
+| **Content starter** (`hugo-agent-zero-child-content`) | Placeholder pages/posts that show shapes (home, about, blog) without kit-dev noise |
+| **Live HAZ.com content** (`hugoagentzero_com-content`) | Real product/docs site — **not** the same job as the starter; may stay richer |
+
+Order of operations: versioning can land first; **public “Start here” waits on vanilla cleanup** (and then template flag on child if not already).
+
+Related: HQ [#21](https://github.com/hugo-agent-zero/hugo-agent-zero/issues/21) is HAZ.com *product* content — separate from “vanilla starter demo.”
+
+---
+
+## Core versioning (Go’s limitation → our workaround)
+
+| Want | Go / Git | What it means |
+|------|----------|---------------|
+| **Latest 1.x (default)** | Branch named **`v1.x.x`** → `hugo mod get …-core@v1.x.x` | Moves when we merge compatible work |
+| **Frozen** | Tag **`v1.2.3`** → `@v1.2.3` | Never moves |
+| **Breaking (rare)** | Branch **`v2.x.x`** + tag `v2.0.0` | New major line; update default once |
+
+`v1.x.x` is a **branch name**, not a Go range. Same job for HX: “always latest compatible 1.x” without hash babysitting.
+
+- **`main`** — day-to-day kit work (can lead briefly)
+- **`v1.x.x`** — what sites and the live demo use; compatible merges only
+- Tags — optional lock points; **never move** an old tag
+- Skip a branch named `v1.0.0` — fights `v1.0.1` / `v1.2.3` tags
+
+---
+
+## Same rule for live demo and site copies
+
+**Child starter** (what people template):
+
+```bash
+hugo mod get github.com/hugo-agent-zero/hugo-agent-zero-core@v1.x.x
+```
+
+Commit `go.mod` + `go.sum`.
+
+**Live Pages** — same line before build so each run refreshes the branch tip:
+
+```yaml
+- name: Use latest 1.x core
+  working-directory: site
+  env:
+    GOPROXY: direct
+  run: hugo mod get github.com/hugo-agent-zero/hugo-agent-zero-core@v1.x.x
+```
+
+Content step unchanged: `content@${{ github.sha }}`.
+
+No special CI-only path. We eat what we ship.
+
+---
+
+## Day-to-day (humans)
+
+| You did | What happens |
+|---------|----------------|
+| Compatible core change | Merge `main` → update **`v1.x.x`** → optional tag → next Pages / site build |
+| Child sysMan change | Merge child → next Pages run |
+| Breaking kit change | **`v2.x.x`** + `v2.0.0`; change default pin docs once |
+
+**No** child pin PR after every core merge if `v1.x.x` moved.
+
+Early on: keep `main` and `v1.x.x` in sync (fast-forward) until a staging gap is useful.
+
+---
+
+## Mum story (README)
+
+> **Start a site:** Use the **child** and **content** GitHub **templates** (not forks). Do not copy core.  
+> **Default:** kit follows the **`v1.x.x`** line — you don’t manage version numbers.  
+> **Want frozen:** pin core to a tag like **`v1.2.3`** once.  
+> **Big break:** rare; kit moves to **`v2.x.x`**.
+
+---
+
+## Honest limits
+
+- `@v1.x.x` = tip of that **branch**, not “highest semver tag”
+- Local `hugo` matches CI if you run the same `mod get`
+- Site org creation (`haz-com` etc.) is a **follow-on** — versioning + template flags should land first so the org copies the right story
+
+---
+
+## Not doing
+
+- npm-style ranges (Go can’t)
+- Moving tags to mean new code
+- Different version rules for live demo vs templates
+- Recommending forks of child/content for new sites
+- Copying / forking core for a normal site
+- Treating current sandbox content as the public starter forever
+
+---
+
+## Test plan
+
+- [ ] Branch `v1.x.x` + tag `v1.0.0` on core
+- [ ] Child + pages both `@v1.x.x`; build OK
+- [ ] Merge to `v1.x.x` → next Pages uses new core without pin PR
+- [ ] Child repo marked as GitHub template
+- [ ] Starter child/content read as vanilla demo (not sandbox shit-show)
+- [ ] HQ #19 / READMEs say template + versioning in plain English
+- [ ] Close #19


### PR DESCRIPTION
## Summary
- Diary: #43 Phases 2–3 + meta grid columns shipped; **Now** points at HAZ.com content next
- Archive: blog list plan marked shipped; #19 versioning plan parked (linked from Now)

## Test plan
- [ ] Skim Meeting 2026-09-03 + Now for cold-start accuracy


Made with [Cursor](https://cursor.com)